### PR TITLE
Singles fives fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,17 @@
 
 /** Validation function which prevents non-numeric input* */
 function validateNumberInput(input){
-    input.value = Math.max(0, input.value.replace(/[^0-9]/g, ''));
+
+        if(input.id === "manualCash"){
+                //Allows numbers and a single decimal point
+                input.value = input.value.replace(/[^0-9.]/g, '');
+                if((input.value.match(/\./g) || []).length > 1){
+                        input.value = input.value.substring(0, input.value.lastIndexOf("."));
+                }
+        } else {
+                //Default case for integer-only fields
+                input.value = input.value.replace(/[^0-9]/g, '');
+        }
 }
 /** Prevents typing letters or negative numbers in field */
 document.querySelectorAll('input[type="number"]').forEach(input => {
@@ -130,7 +140,7 @@ function calculateSafe() {
 
     //Calculate Total
     const bandedCash = getInt("bandedCash") * 1000;
-    const singlesFivesTotal = (getInt("singles") * 100) + (getInt("fives") * 500);
+    const singlesFivesTotal = getInt("singles") + getInt("fives");
     const manualCash = getFloat("manualCash") || 0;
     const grandTotal = bandedCash + coinsTotal + singlesFivesTotal + manualCash + lotteryTotal + stampsTotal;
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       <div id="manualField" class="grid grid-cols-1 md:grid-cols-2 gap-4"></div>
 
       <label for="manualCash" class="block text-gray-700">Manual Cash Amount:</label>
-      <input id="manualCash" type="number" class="w-full p-2 border rounded">
+      <input id="manualCash" inputmode="decimal" class="w-full p-2 border rounded" oninput="validateNumberInput(this)">
     </fieldset>
 
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,11 @@
       <div id="manualField" class="grid grid-cols-1 md:grid-cols-2 gap-4"></div>
 
       <label for="manualCash" class="block text-gray-700">Manual Cash Amount:</label>
-      <input id="manualCash" inputmode="decimal" class="w-full p-2 border rounded" oninput="validateNumberInput(this)">
+      <input id="manualCash" 
+      inputmode="decimal" 
+      pattern="[0-9]*\.?[0-9*]*"
+      class="w-full p-2 border rounded" 
+      oninput="validateNumberInput(this)">
     </fieldset>
 
 
@@ -38,10 +42,18 @@
       <legend class="font-semibold">Singles and Fives (Bands)</legend>
 
       <label for="singles" class="block">Singles (Bands of $100):</label>
-      <input type = "number" id="singles" class = "w-full p-2 border rounded" min="0" step = "1" oninput="validateNumberInput(this)">
+      <input type = "text" id="singles" 
+      class = "w-full p-2 border rounded" 
+      inputmode="numeric"
+      pattern="[0-9]*"
+      oninput="validateNumberInput(this)">
 
       <label for="fives" class="block mt-2">Fives (Bands of $500):</label>
-      <input type = "number" id="fives" class = "w-full p-2 border rounded" min="0" step = "1" oninput="validateNumberInput(this)">
+      <input type ="text" id="fives" 
+      class = "w-full p-2 border rounded" 
+      inputmode="numeric"
+      pattern="[0-9]*"
+      oninput="validateNumberInput(this)">
     </fieldset>
 
     <!--Stamps-->


### PR DESCRIPTION
Hey Tim.

I went on ahead in this update and removed the multiplier for the five and singles. This should prevent confusions in your recently listed issue. Drop downs I feel would be too much on the screen especially in increments ranging from 100-4000 for ones. 

This update allows the user to input any number value, prevents decimals from being put into the fives/singles but allows decimal for manual cash using the `validateNumberInput` function for all of these, and then should show number pad only on mobile.